### PR TITLE
feat: support artifacts

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "agent-protocol"]
+	path = agent-protocol
+	url = https://github.com/AI-Engineers-Foundation/agent-protocol

--- a/README.md
+++ b/README.md
@@ -41,3 +41,12 @@ Agent.handleTask(taskHandler).start()
 ## Docs
 
 You can find more info and examples in the [docs](https://agentprotocol.ai/sdks/js).
+
+## Contributing
+```bash
+git clone https://github.com/AI-Engineers-Foundation/agent-protocol-sdk-js
+cd ./agent-protocol-sdk-js
+git submodule update --init
+npm install
+npm run build
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
+        "@types/uuid": "^9.0.2",
         "express": "^4.18.2",
         "express-openapi-validator": "^5.0.4",
         "js-yaml": "^4.1.0",
@@ -18,7 +19,6 @@
         "@types/express": "^4.17.17",
         "@types/js-yaml": "^4.0.5",
         "@types/node": "^20.4.1",
-        "@types/uuid": "^9.0.2",
         "prettier": "^3.0.0",
         "tsup": "^7.1.0",
         "typescript": "^5.1.6"
@@ -567,7 +567,6 @@
     },
     "node_modules/@types/uuid": {
       "version": "9.0.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/accepts": {

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
     "email": "hello@e2b.dev",
     "url": "https://e2b.dev"
   },
-  "bugs": "https://github.com/e2b-dev/agent-protocol/issues",
+  "bugs": "https://github.com/e2b-dev/agent-protocol-sdk-js/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/e2b-dev/agent-protocol/tree/main/agent/js"
+    "url": "https://github.com/e2b-dev/agent-protocol-sdk-js"
   },
   "main": "./dist/index.js",
   "types": "dist/index.d.ts",
@@ -26,7 +26,6 @@
     "@types/express": "^4.17.17",
     "@types/js-yaml": "^4.0.5",
     "@types/node": "^20.4.1",
-    "@types/uuid": "^9.0.2",
     "prettier": "^3.0.0",
     "tsup": "^7.1.0",
     "typescript": "^5.1.6"
@@ -50,6 +49,7 @@
     "wrapper"
   ],
   "dependencies": {
+    "@types/uuid": "^9.0.2",
     "express": "^4.18.2",
     "express-openapi-validator": "^5.0.4",
     "js-yaml": "^4.1.0",

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -440,14 +440,17 @@ export class Agent {
 
   static handleTask(
     taskHandler: TaskHandler,
-    config: AgentConfig = defaultAgentConfig
+    config: Partial<AgentConfig>
   ): Agent {
-    return new Agent(taskHandler, config);
+    return new Agent(taskHandler, {
+      workspace: config.workspace || defaultAgentConfig.workspace,
+      port: config.port || defaultAgentConfig.port
+    });
   }
 
   start(port?: number): void {
     const config: ApiConfig = {
-      port: port || this.config.port,
+      port: port || this.config.port || defaultAgentConfig.port,
       routes: [
         registerCreateAgentTask,
         registerListAgentTaskIDs,

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -192,6 +192,7 @@ export const executeAgentTaskStep = async (
     task_id: taskId,
     step_id: uuid(),
     input: body?.input ?? null,
+    name: stepResult.name,
     output: stepResult.output ?? null,
     artifacts: stepResult.artifacts ?? [],
     is_last: stepResult.is_last ?? false,

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1,7 +1,7 @@
 
 import { v4 as uuid } from 'uuid'
-import fs from 'fs'
-import path from 'path'
+import * as fs from 'fs'
+import * as path from 'path'
 
 import {
   type TaskInput,

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -2,6 +2,8 @@ import * as OpenApiValidator from 'express-openapi-validator'
 import express from 'express'
 import { v4 as uuid } from 'uuid'
 import yaml from 'js-yaml'
+import fs from 'fs'
+import path from 'path'
 
 import {
   type TaskInput,
@@ -13,6 +15,7 @@ import {
   type StepResult,
   type Task,
   type TaskRequestBody,
+  StepStatus,
 } from './models'
 
 import spec from '../../../schemas/openapi.yml'
@@ -22,6 +25,8 @@ const app = express()
 app.use(express.json())
 app.use(express.text())
 app.use(express.urlencoded({ extended: false }))
+
+const WORKSPACE = process.env.AGENT_WORKSPACE ?? 'workspace'
 
 app.get('/openapi.yaml', (_, res) => {
   res.setHeader('Content-Type', 'text/yaml').status(200).send(spec)
@@ -46,7 +51,10 @@ export type StepHandler = (input: StepInput | null) => Promise<StepResult>
  * A function that handles a task.
  * Returns a step handler.
  */
-export type TaskHandler = (input: TaskInput | null) => Promise<StepHandler>
+export type TaskHandler = (
+  taskId: String,
+  input: TaskInput | null
+) => Promise<StepHandler>
 
 const tasks: Array<[Task, StepHandler]> = []
 const steps: Step[] = []
@@ -74,12 +82,12 @@ export const createAgentTask = async (
   if (taskHandler == null) {
     throw new Error('Task handler not defined')
   }
-  const stepHandler = await taskHandler(body?.input ?? null)
   const task: Task = {
     task_id: uuid(),
     input: body?.input ?? null,
     artifacts: [],
   }
+  const stepHandler = await taskHandler(task.task_id, body?.input ?? null)
   tasks.push([task, stepHandler])
   return task
 }
@@ -187,13 +195,13 @@ export const executeAgentTaskStep = async (
     output: stepResult.output ?? null,
     artifacts: stepResult.artifacts ?? [],
     is_last: stepResult.is_last ?? false,
+    status: StepStatus.COMPLETED,
   }
-  if (step.artifacts != null) {
-    if (task[0].artifacts == null || task[0].artifacts.length === 0) {
-      task[0].artifacts = step.artifacts
-    } else {
-      task[0].artifacts.push(...step.artifacts)
-    }
+
+  // If there are artifacts in the step, append them to the task's artifacts array (or initialize it if necessary)
+  if (step.artifacts && step.artifacts.length > 0) {
+    task[0].artifacts = task[0].artifacts ?? []
+    task[0].artifacts.push(...step.artifacts)
   }
   steps.push(step)
   return step
@@ -241,6 +249,154 @@ app.get('/agent/tasks/:task_id/steps/:step_id', (req, res) => {
     } catch (err: Error | any) {
       console.error(err)
       res.status(500).json({ error: err.message })
+    }
+  })()
+})
+
+/**
+ * Get path of an artifact associated to a task
+ * @param taskId Task associated with artifact
+ * @param artifact Artifact associated with the path returned
+ * @returns Absolute path of the artifact
+ */
+export const getArtifactPath = (taskId: string, artifact: Artifact): string => {
+  return path.join(
+    process.cwd(),
+    WORKSPACE,
+    taskId,
+    artifact.relative_path ?? '',
+    artifact.file_name
+  )
+}
+
+app.get('/agent/tasks/:task_id/artifacts', (req, res) => {
+  void (async () => {
+    const taskId = req.params.task_id
+    try {
+      const task = await getAgentTask(taskId)
+      const current_page = Number(req.query['current_page']) || 1
+      const page_size = Number(req.query['page_size']) || 10
+
+      if (!task.artifacts) {
+        return res.status(200).send({
+          artifacts: [],
+          pagination: {
+            total_items: 0,
+            total_pages: 0,
+            current_page,
+            page_size,
+          },
+        })
+      }
+      const total_items = task.artifacts.length
+      const total_pages = Math.ceil(total_items / page_size)
+
+      // Slice artifacts array based on pagination
+      const start = (current_page - 1) * page_size
+      const end = start + page_size
+      const pagedArtifacts = task.artifacts.slice(start, end)
+
+      res.status(200).send({
+        artifacts: pagedArtifacts,
+        pagination: {
+          total_items,
+          total_pages,
+          current_page,
+          page_size,
+        },
+      })
+    } catch (err: Error | any) {
+      console.error(err)
+      res.status(404).json({ error: err.message })
+    }
+  })()
+})
+
+/**
+ * Creates an artifact for a task
+ * @param task Task associated with new artifact
+ * @param file File that will be added as artifact
+ * @param relativePath Relative path where the artifact might be stored. Can be undefined
+ */
+export const createArtifact = async (
+  task: Task,
+  file: any,
+  relativePath?: string
+): Promise<Artifact> => {
+  const artifactId = uuid()
+  const artifact: Artifact = {
+    artifact_id: artifactId,
+    agent_created: false,
+    file_name: file.originalname,
+    relative_path: relativePath || null,
+    created_at: Date.now().toString(),
+  }
+  task.artifacts = task.artifacts || []
+  task.artifacts.push(artifact)
+
+  const artifactFolderPath = getArtifactPath(task.task_id, artifact)
+
+  // Save file to server's file system
+  fs.mkdirSync(path.join(artifactFolderPath, '..'), { recursive: true })
+  fs.writeFileSync(artifactFolderPath, file.buffer)
+  return artifact
+}
+
+app.post('/agent/tasks/:task_id/artifacts', (req, res) => {
+  void (async () => {
+    try {
+      const taskId = req.params.task_id
+      const relativePath = req.body.relative_path
+
+      const task = tasks.find(([{ task_id }]) => task_id == taskId)
+      if (!task) {
+        return res
+          .status(404)
+          .json({ message: 'Unable to find task with the provided id' })
+      }
+
+      const files = req.files as Array<Express.Multer.File>
+      let file = files.find(({ fieldname }) => fieldname == 'file')
+      const artifact = await createArtifact(task[0], file, relativePath)
+      res.status(200).json(artifact)
+    } catch (err: Error | any) {
+      console.error(err)
+      res.status(500).json({ error: err.message })
+    }
+  })()
+})
+
+/**
+ * Get an artifact of a task
+ * @param taskId ID of task associated with artifact
+ * @param artifactId ID of artifact to be retrieved
+ * @returns A stored artifact
+ */
+export const getTaskArtifact = async (
+  taskId: string,
+  artifactId: string
+): Promise<Artifact> => {
+  const task = await getAgentTask(taskId)
+  const artifact = task.artifacts?.find((a) => a.artifact_id === artifactId)
+  if (!artifact) {
+    throw new Error(
+      `Artifact with id ${artifactId} in task with id ${taskId} was not found`
+    )
+  }
+  return artifact
+}
+
+app.get('/agent/tasks/:task_id/artifacts/:artifact_id', (req, res) => {
+  void (async () => {
+    const taskId = req.params.task_id
+    const artifactId = req.params.artifact_id
+    try {
+      const artifact = await getTaskArtifact(taskId, artifactId)
+      const artifactPath = getArtifactPath(taskId, artifact)
+      res.status(200).sendFile(artifactPath)
+    } catch (err: Error | any) {
+      console.error(err)
+      res.status(404).json({ error: err.message })
     }
   })()
 })

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1,7 +1,5 @@
-import * as OpenApiValidator from 'express-openapi-validator'
-import express from 'express'
+
 import { v4 as uuid } from 'uuid'
-import yaml from 'js-yaml'
 import fs from 'fs'
 import path from 'path'
 
@@ -17,30 +15,13 @@ import {
   type TaskRequestBody,
   StepStatus,
 } from './models'
-
-import spec from '../../../schemas/openapi.yml'
-
-const app = express()
-
-app.use(express.json())
-app.use(express.text())
-app.use(express.urlencoded({ extended: false }))
-
-const WORKSPACE = process.env.AGENT_WORKSPACE ?? 'workspace'
-
-app.get('/openapi.yaml', (_, res) => {
-  res.setHeader('Content-Type', 'text/yaml').status(200).send(spec)
-})
-
-const parsedSpec = yaml.load(spec)
-
-app.use(
-  OpenApiValidator.middleware({
-    apiSpec: parsedSpec as any,
-    validateRequests: true, // (default)
-    validateResponses: true, // false by default
-  })
-)
+import {
+  createApi,
+  ApiApp,
+  ApiConfig,
+  RouteRegisterFn,
+  RouteContext,
+} from "./api";
 
 /**
  * A function that handles a step in a task.
@@ -91,17 +72,19 @@ export const createAgentTask = async (
   tasks.push([task, stepHandler])
   return task
 }
-app.post('/agent/tasks', (req, res) => {
-  void (async () => {
-    try {
-      const task = await createAgentTask(req.body)
-      res.status(200).json(task)
-    } catch (err: Error | any) {
-      console.error(err)
-      res.status(500).json({ error: err.message })
-    }
-  })()
-})
+const registerCreateAgentTask: RouteRegisterFn = (app: ApiApp) => {
+  return app.post('/agent/tasks', (req, res) => {
+    void (async () => {
+      try {
+        const task = await createAgentTask(req.body)
+        res.status(200).json(task)
+      } catch (err: Error | any) {
+        console.error(err)
+        res.status(500).json({ error: err.message })
+      }
+    })()
+  });
+}
 
 /**
  * Lists all tasks that have been created for the agent.
@@ -110,17 +93,19 @@ app.post('/agent/tasks', (req, res) => {
 export const listAgentTaskIDs = async (): Promise<string[]> => {
   return tasks.map(([task, _]) => task.task_id)
 }
-app.get('/agent/tasks', (req, res) => {
-  void (async () => {
-    try {
-      const ids = await listAgentTaskIDs()
-      res.status(200).json(ids)
-    } catch (err: Error | any) {
-      console.error(err)
-      res.status(500).json({ error: err.message })
-    }
-  })()
-})
+const registerListAgentTaskIDs: RouteRegisterFn = (app: ApiApp) => {
+  return app.get('/agent/tasks', (req, res) => {
+    void (async () => {
+      try {
+        const ids = await listAgentTaskIDs()
+        res.status(200).json(ids)
+      } catch (err: Error | any) {
+        console.error(err)
+        res.status(500).json({ error: err.message })
+      }
+    })()
+  })
+}
 
 /**
  * Get details about a specified agent task.
@@ -134,17 +119,19 @@ export const getAgentTask = async (taskId: string): Promise<Task> => {
   }
   return task[0]
 }
-app.get('/agent/tasks/:task_id', (req, res) => {
-  void (async () => {
-    try {
-      const task = await getAgentTask(req.params.task_id)
-      res.status(200).json(task)
-    } catch (err: Error | any) {
-      console.error(err)
-      res.status(500).json({ error: err.message })
-    }
-  })()
-})
+const registerGetAgentTask: RouteRegisterFn = (app: ApiApp) => {
+  return app.get('/agent/tasks/:task_id', (req, res) => {
+    void (async () => {
+      try {
+        const task = await getAgentTask(req.params.task_id)
+        res.status(200).json(task)
+      } catch (err: Error | any) {
+        console.error(err)
+        res.status(500).json({ error: err.message })
+      }
+    })()
+  })
+}
 
 /**
  * Lists all steps for the specified task.
@@ -160,17 +147,19 @@ export const listAgentTaskSteps = async (taskId: string): Promise<string[]> => {
     .filter((step) => step.task_id === taskId)
     .map((step) => step.step_id)
 }
-app.get('/agent/tasks/:task_id/steps', (req, res) => {
-  void (async () => {
-    try {
-      const ids = await listAgentTaskSteps(req.params.task_id)
-      res.status(200).json(ids)
-    } catch (err: Error | any) {
-      console.error(err)
-      res.status(500).json({ error: err.message })
-    }
-  })()
-})
+const registerListAgentTaskSteps: RouteRegisterFn = (app: ApiApp) => {
+  return app.get('/agent/tasks/:task_id/steps', (req, res) => {
+    void (async () => {
+      try {
+        const ids = await listAgentTaskSteps(req.params.task_id)
+        res.status(200).json(ids)
+      } catch (err: Error | any) {
+        console.error(err)
+        res.status(500).json({ error: err.message })
+      }
+    })()
+  })
+}
 
 /**
  * Execute a step in the specified agent task.
@@ -207,17 +196,19 @@ export const executeAgentTaskStep = async (
   steps.push(step)
   return step
 }
-app.post('/agent/tasks/:task_id/steps', (req, res) => {
-  void (async () => {
-    try {
-      const step = await executeAgentTaskStep(req.params.task_id, req.body)
-      res.status(200).json(step)
-    } catch (err: Error | any) {
-      console.error(err)
-      res.status(500).json({ error: err.message })
-    }
-  })()
-})
+const registerExecuteAgentTaskStep: RouteRegisterFn = (app: ApiApp) => {
+  return app.post('/agent/tasks/:task_id/steps', (req, res) => {
+    void (async () => {
+      try {
+        const step = await executeAgentTaskStep(req.params.task_id, req.body)
+        res.status(200).json(step)
+      } catch (err: Error | any) {
+        console.error(err)
+        res.status(500).json({ error: err.message })
+      }
+    })()
+  })
+}
 
 /**
  * Get details about a specified task step.
@@ -239,20 +230,73 @@ export const getAgentTaskStep = async (
   }
   return step
 }
-app.get('/agent/tasks/:task_id/steps/:step_id', (req, res) => {
-  void (async () => {
-    try {
-      const step = await getAgentTaskStep(
-        req.params.task_id,
-        req.params.step_id
-      )
-      res.status(200).json(step)
-    } catch (err: Error | any) {
-      console.error(err)
-      res.status(500).json({ error: err.message })
-    }
-  })()
-})
+const registerGetAgentTaskStep: RouteRegisterFn = (app: ApiApp) => {
+  return app.get('/agent/tasks/:task_id/steps/:step_id', (req, res) => {
+    void (async () => {
+      try {
+        const step = await getAgentTaskStep(
+          req.params.task_id,
+          req.params.step_id
+        )
+        res.status(200).json(step)
+      } catch (err: Error | any) {
+        console.error(err)
+        res.status(500).json({ error: err.message })
+      }
+    })()
+  })
+}
+
+export const getArtifacts = async (
+  taskId: string
+): Promise<Artifact[] | undefined> => {
+  const task = await getAgentTask(taskId);
+  return task.artifacts;
+}
+const registerGetArtifacts: RouteRegisterFn = (app: ApiApp) => {
+  return app.get('/agent/tasks/:task_id/artifacts', (req, res) => {
+    void (async () => {
+      const taskId = req.params.task_id
+      try {
+        const artifacts = await getArtifacts(taskId)
+        const current_page = Number(req.query['current_page']) || 1
+        const page_size = Number(req.query['page_size']) || 10
+  
+        if (!artifacts) {
+          return res.status(200).send({
+            artifacts: [],
+            pagination: {
+              total_items: 0,
+              total_pages: 0,
+              current_page,
+              page_size,
+            },
+          })
+        }
+        const total_items = artifacts.length
+        const total_pages = Math.ceil(total_items / page_size)
+
+        // Slice artifacts array based on pagination
+        const start = (current_page - 1) * page_size
+        const end = start + page_size
+        const pagedArtifacts = artifacts.slice(start, end)
+
+        res.status(200).send({
+          artifacts: pagedArtifacts,
+          pagination: {
+            total_items,
+            total_pages,
+            current_page,
+            page_size,
+          },
+        })
+      } catch (err: Error | any) {
+        console.error(err)
+        res.status(404).json({ error: err.message })
+      }
+    })()
+  })
+}
 
 /**
  * Get path of an artifact associated to a task
@@ -260,58 +304,22 @@ app.get('/agent/tasks/:task_id/steps/:step_id', (req, res) => {
  * @param artifact Artifact associated with the path returned
  * @returns Absolute path of the artifact
  */
-export const getArtifactPath = (taskId: string, artifact: Artifact): string => {
+export const getArtifactPath = (
+  taskId: string,
+  workspace: string,
+  artifact: Artifact
+): string => {
+  const rootDir = path.isAbsolute(workspace) ?
+    workspace :
+    path.join(process.cwd(), workspace);
+
   return path.join(
-    process.cwd(),
-    WORKSPACE,
+    rootDir,
     taskId,
     artifact.relative_path ?? '',
     artifact.file_name
   )
 }
-
-app.get('/agent/tasks/:task_id/artifacts', (req, res) => {
-  void (async () => {
-    const taskId = req.params.task_id
-    try {
-      const task = await getAgentTask(taskId)
-      const current_page = Number(req.query['current_page']) || 1
-      const page_size = Number(req.query['page_size']) || 10
-
-      if (!task.artifacts) {
-        return res.status(200).send({
-          artifacts: [],
-          pagination: {
-            total_items: 0,
-            total_pages: 0,
-            current_page,
-            page_size,
-          },
-        })
-      }
-      const total_items = task.artifacts.length
-      const total_pages = Math.ceil(total_items / page_size)
-
-      // Slice artifacts array based on pagination
-      const start = (current_page - 1) * page_size
-      const end = start + page_size
-      const pagedArtifacts = task.artifacts.slice(start, end)
-
-      res.status(200).send({
-        artifacts: pagedArtifacts,
-        pagination: {
-          total_items,
-          total_pages,
-          current_page,
-          page_size,
-        },
-      })
-    } catch (err: Error | any) {
-      console.error(err)
-      res.status(404).json({ error: err.message })
-    }
-  })()
-})
 
 /**
  * Creates an artifact for a task
@@ -320,6 +328,7 @@ app.get('/agent/tasks/:task_id/artifacts', (req, res) => {
  * @param relativePath Relative path where the artifact might be stored. Can be undefined
  */
 export const createArtifact = async (
+  workspace: string,
   task: Task,
   file: any,
   relativePath?: string
@@ -335,37 +344,47 @@ export const createArtifact = async (
   task.artifacts = task.artifacts || []
   task.artifacts.push(artifact)
 
-  const artifactFolderPath = getArtifactPath(task.task_id, artifact)
+  const artifactFolderPath = getArtifactPath(
+    task.task_id,
+    workspace,
+    artifact
+  )
 
   // Save file to server's file system
   fs.mkdirSync(path.join(artifactFolderPath, '..'), { recursive: true })
   fs.writeFileSync(artifactFolderPath, file.buffer)
   return artifact
 }
+const registerCreateArtifact: RouteRegisterFn = (app: ApiApp, context: RouteContext) => {
+  return app.post('/agent/tasks/:task_id/artifacts', (req, res) => {
+    void (async () => {
+      try {
+        const taskId = req.params.task_id
+        const relativePath = req.body.relative_path
 
-app.post('/agent/tasks/:task_id/artifacts', (req, res) => {
-  void (async () => {
-    try {
-      const taskId = req.params.task_id
-      const relativePath = req.body.relative_path
+        const task = tasks.find(([{ task_id }]) => task_id == taskId)
+        if (!task) {
+          return res
+            .status(404)
+            .json({ message: 'Unable to find task with the provided id' })
+        }
 
-      const task = tasks.find(([{ task_id }]) => task_id == taskId)
-      if (!task) {
-        return res
-          .status(404)
-          .json({ message: 'Unable to find task with the provided id' })
+        const files = req.files as Array<Express.Multer.File>
+        let file = files.find(({ fieldname }) => fieldname == 'file')
+        const artifact = await createArtifact(
+          context.workspace,
+          task[0],
+          file,
+          relativePath
+        )
+        res.status(200).json(artifact)
+      } catch (err: Error | any) {
+        console.error(err)
+        res.status(500).json({ error: err.message })
       }
-
-      const files = req.files as Array<Express.Multer.File>
-      let file = files.find(({ fieldname }) => fieldname == 'file')
-      const artifact = await createArtifact(task[0], file, relativePath)
-      res.status(200).json(artifact)
-    } catch (err: Error | any) {
-      console.error(err)
-      res.status(500).json({ error: err.message })
-    }
-  })()
-})
+    })()
+  })
+}
 
 /**
  * Get an artifact of a task
@@ -386,31 +405,68 @@ export const getTaskArtifact = async (
   }
   return artifact
 }
+const registerGetTaskArtifact: RouteRegisterFn = (app: ApiApp, context: RouteContext) => {
+  return app.get('/agent/tasks/:task_id/artifacts/:artifact_id', (req, res) => {
+    void (async () => {
+      const taskId = req.params.task_id
+      const artifactId = req.params.artifact_id
+      try {
+        const artifact = await getTaskArtifact(taskId, artifactId)
+        const artifactPath = getArtifactPath(taskId, context.workspace, artifact)
+        res.status(200).sendFile(artifactPath)
+      } catch (err: Error | any) {
+        console.error(err)
+        res.status(404).json({ error: err.message })
+      }
+    })()
+  })
+}
 
-app.get('/agent/tasks/:task_id/artifacts/:artifact_id', (req, res) => {
-  void (async () => {
-    const taskId = req.params.task_id
-    const artifactId = req.params.artifact_id
-    try {
-      const artifact = await getTaskArtifact(taskId, artifactId)
-      const artifactPath = getArtifactPath(taskId, artifact)
-      res.status(200).sendFile(artifactPath)
-    } catch (err: Error | any) {
-      console.error(err)
-      res.status(404).json({ error: err.message })
-    }
-  })()
-})
+export interface AgentConfig {
+  port: number;
+  workspace: string;
+}
+
+export const defaultAgentConfig: AgentConfig = {
+  port: 8000,
+  workspace: "./workspace"
+};
 
 export class Agent {
-  static handleTask(handler: TaskHandler): typeof Agent {
-    taskHandler = handler
-    return this
+  constructor(
+    public taskHandler: TaskHandler,
+    public config: AgentConfig
+  ) { }
+
+  static handleTask(
+    taskHandler: TaskHandler,
+    config: AgentConfig = defaultAgentConfig
+  ): Agent {
+    return new Agent(taskHandler, config);
   }
 
-  static start(port: number = 8000): void {
-    app.listen(port, () => {
-      console.log(`Agent listening at http://localhost:${port}`)
-    })
+  start(port?: number): void {
+    const config: ApiConfig = {
+      port: port || this.config.port,
+      routes: [
+        registerCreateAgentTask,
+        registerListAgentTaskIDs,
+        registerGetAgentTask,
+        registerListAgentTaskSteps,
+        registerExecuteAgentTaskStep,
+        registerGetAgentTaskStep,
+        registerGetArtifacts,
+        registerCreateArtifact,
+        registerGetTaskArtifact
+      ],
+      callback: () => {
+        console.log(`Agent listening at http://localhost:${this.config.port}`)
+      },
+      context: {
+        workspace: this.config.workspace
+      },
+    }
+
+    createApi(config)
   }
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,0 +1,52 @@
+import * as OpenApiValidator from 'express-openapi-validator'
+import yaml from 'js-yaml'
+import express from 'express'
+import * as core from 'express-serve-static-core';
+
+import spec from '../../../schemas/openapi.yml'
+
+export type ApiApp = core.Express;
+
+export interface RouteContext {
+  workspace: string;
+}
+
+export type RouteRegisterFn = (
+  app: ApiApp,
+  context: RouteContext
+) => ApiApp;
+
+export interface ApiConfig {
+  context: RouteContext;
+  port: number;
+  callback?: () => void;
+  routes: RouteRegisterFn[];
+}
+
+export const createApi = (config: ApiConfig) => {
+  const app = express()
+
+  app.use(express.json())
+  app.use(express.text())
+  app.use(express.urlencoded({ extended: false }))
+
+  const parsedSpec = yaml.load(spec)
+
+  app.use(
+    OpenApiValidator.middleware({
+      apiSpec: parsedSpec as any,
+      validateRequests: true, // (default)
+      validateResponses: true, // false by default
+    })
+  )
+
+  app.get('/openapi.yaml', (_, res) => {
+    res.setHeader('Content-Type', 'text/yaml').status(200).send(spec)
+  })
+
+  for (const route of config.routes) {
+    route(app, config.context);
+  }
+
+  app.listen(config.port, config.callback)
+}

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,9 +1,9 @@
-import * as OpenApiValidator from 'express-openapi-validator'
-import yaml from 'js-yaml'
-import express from 'express'
-import * as core from 'express-serve-static-core';
+import * as OpenApiValidator from "express-openapi-validator";
+import yaml from "js-yaml";
+import express, { Router } from "express";  // <-- Import Router
+import * as core from "express-serve-static-core";
 
-import spec from '../../agent-protocol/schemas/openapi.yml'
+import spec from "../agent-protocol/schemas/openapi.yml";
 
 export type ApiApp = core.Express;
 
@@ -12,9 +12,9 @@ export interface RouteContext {
 }
 
 export type RouteRegisterFn = (
-  app: ApiApp,
+  app: Router,
   context: RouteContext
-) => ApiApp;
+) => void;
 
 export interface ApiConfig {
   context: RouteContext;
@@ -24,13 +24,13 @@ export interface ApiConfig {
 }
 
 export const createApi = (config: ApiConfig) => {
-  const app = express()
+  const app = express();
 
-  app.use(express.json())
-  app.use(express.text())
-  app.use(express.urlencoded({ extended: false }))
+  app.use(express.json());
+  app.use(express.text());
+  app.use(express.urlencoded({ extended: false }));
 
-  const parsedSpec = yaml.load(spec)
+  const parsedSpec = yaml.load(spec);
 
   app.use(
     OpenApiValidator.middleware({
@@ -38,15 +38,18 @@ export const createApi = (config: ApiConfig) => {
       validateRequests: true, // (default)
       validateResponses: true, // false by default
     })
-  )
+  );
 
-  app.get('/openapi.yaml', (_, res) => {
-    res.setHeader('Content-Type', 'text/yaml').status(200).send(spec)
-  })
+  app.get("/openapi.yaml", (_, res) => {
+    res.setHeader("Content-Type", "text/yaml").status(200).send(spec);
+  });
 
-  for (const route of config.routes) {
-    route(app, config.context);
-  }
+  const router = Router();
 
-  app.listen(config.port, config.callback)
-}
+  config.routes.map((route) => {
+    route(router, config.context);
+  });
+
+  app.use("/ap/v1", router);
+  app.listen(config.port, config.callback);
+};

--- a/src/api.ts
+++ b/src/api.ts
@@ -3,7 +3,7 @@ import yaml from 'js-yaml'
 import express from 'express'
 import * as core from 'express-serve-static-core';
 
-import spec from '../../../schemas/openapi.yml'
+import spec from '../../agent-protocol/schemas/openapi.yml'
 
 export type ApiApp = core.Express;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,4 +41,6 @@ export {
   getAgentTaskStep,
 }
 
+export { v4 } from "uuid"
+
 export default Agent

--- a/src/models.ts
+++ b/src/models.ts
@@ -31,6 +31,13 @@ export enum StepStatus {
 }
 
 export interface Step {
+  /**
+   * The name of the task step
+   */
+  name?: string
+  /**
+   * Output of the task step
+   */
   output?: StepOutput
   /**
    * A list of artifacts that the step has produced.
@@ -60,6 +67,13 @@ export interface StepRequestBody {
 }
 
 export interface StepResult {
+  /**
+   * The name of the step
+   */
+  name?: string
+  /**
+   * Output of the step
+   */
   output?: StepOutput
   /**
    * A list of artifacts that the step has produced.

--- a/src/models.ts
+++ b/src/models.ts
@@ -6,7 +6,13 @@ export type TaskInput = any
 /**
  * Artifact that the task has produced. Any value is allowed.
  */
-export type Artifact = any
+export type Artifact = {
+  artifact_id: string,
+  agent_created: boolean,
+  file_name: string,
+  relative_path: string | null,
+  created_at: string
+}
 
 /**
  * Input parameters for the task step. Any value is allowed.
@@ -17,6 +23,12 @@ export type StepInput = any
  * Output that the task step has produced. Any value is allowed.
  */
 export type StepOutput = any
+
+export enum StepStatus {
+  CREATED = "created",
+  RUNNING = "running",
+  COMPLETED = "completed"
+}
 
 export interface Step {
   output?: StepOutput
@@ -37,6 +49,10 @@ export interface Step {
    * The ID of the task step.
    */
   step_id: string
+  /**
+   * Current status of step
+   */
+  status: StepStatus
 }
 
 export interface StepRequestBody {


### PR DESCRIPTION
migrating PR from the old repo https://github.com/AI-Engineers-Foundation/agent-protocol/pull/68 to this new repo :smile:

### Things updated in this PR
- linked the specs yaml file from the agent protocol repository using git submodule
- added the `ap/v1` base url
- re-exported `uuid` library, being the reason that there are some cases where the agent creates some artifacts, and these need to have their own uuid (since that's how the spec defines it)
- i want to re-iterate the request for feedback regarding how steps are handled :pray:

please let me know what else we need for this to get merged and released so people can use it in the hackathon